### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,17 @@ A robust Model Context Protocol (MCP) server that provides secure shell command 
 > 🧠💥🖥️ *Think of `mcp-shell` as the command-line actuator for your LLM.*
 > While language models reason about the world, `mcp-shell` is what lets them **touch it**.
 
+<a href="https://glama.ai/mcp/servers/@sonirico/mcp-shell">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@sonirico/mcp-shell/badge" alt="mcp-shell MCP server" />
+</a>
+
 ## What is this?
 
 This tool creates a bridge between AI systems and your shell environment through the standardized MCP protocol. It exposes the system shell as a structured tool, enabling autonomous workflows, tool-assisted reasoning, and real-world problem solving.
 
 Built on top of the official MCP SDK for Go: [mark3labs/mcp-go](https://github.com/mark3labs/mcp-go).
 
-It's written in Go, integrates directly with `mcp-go`, and provides a clean path from thought to execution. I'm aware similar projects exist — this one’s mine. It solves the problem the way I want it solved: minimal, composable, auditable.
+It's written in Go, integrates directly with `mcp-go`, and provides a clean path from thought to execution. I'm aware similar projects exist — this one's mine. It solves the problem the way I want it solved: minimal, composable, auditable.
 
 Out of the box it runs isolated via Docker, but that's just a start. The roadmap includes support for optional jailing mechanisms like `chroot`, namespaces, and syscall-level confinement — without depending on Docker for everything.
 


### PR DESCRIPTION
This PR adds a badge for the [mcp-shell](https://glama.ai/mcp/servers/@sonirico/mcp-shell) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@sonirico/mcp-shell">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@sonirico/mcp-shell/badge" alt="mcp-shell MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.