### PR TITLE
feat: publish Docker image to Docker Hub on release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,49 @@
+name: Docker Publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=dev" >> $GITHUB_OUTPUT
+          fi
+          echo "build_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            sonirico/mcp-shell:${{ steps.meta.outputs.version }}
+            sonirico/mcp-shell:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
+            COMMIT_HASH=${{ github.sha }}
+            BUILD_TIME=${{ steps.meta.outputs.build_time }}

--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ MCP_SHELL_LOG_LEVEL=debug mcp-shell
 
 ### Docker Deployment (Recommended)
 
+Pull the image from Docker Hub (no build required):
+
+```bash
+docker run -it --rm -v /tmp/mcp-workspace:/tmp/mcp-workspace sonirico/mcp-shell:latest
+```
+
+Or build locally:
+
 ```bash
 # Build Docker image
 make docker-build
@@ -173,9 +181,8 @@ security:
   "mcpServers": {
     "shell": {
       "command": "docker",
-      "args": ["run", "--rm", "-i", "mcp-shell:latest"],
+      "args": ["run", "--rm", "-i", "sonirico/mcp-shell:latest"],
       "env": {
-        "MCP_SHELL_SECURITY_ENABLED": "true",
         "MCP_SHELL_LOG_LEVEL": "info"
       }
     }


### PR DESCRIPTION
Fixes #1

**Changes:**
- Add GitHub Actions workflow (\.github/workflows/docker-publish\.yml) that builds and pushes the image to Docker Hub
- Triggers on:
  - `release: published` — publishes `sonirico/mcp-shell:<tag>` and `sonirico/mcp-shell:latest`
  - `workflow_dispatch` — manual run for testing
- Update README with Docker Hub pull instructions and fix Claude Desktop example to use `sonirico/mcp-shell:latest`

**Setup required:** Add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets to the repository settings. Create the `sonirico/mcp-shell` repository on Docker Hub if it doesn't exist.

Once merged and a release is published, users can run:
```bash
docker run -it --rm sonirico/mcp-shell:latest
```
