### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,3 +143,8 @@ make release            # binary + docker image
 ## Contributing
 
 Fork, branch, `make fmt test`, open a PR.
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/sonirico-mcp-shell).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/sonirico-mcp-shell).