### PR TITLE
fix: secure mode by default + keep interpreters out of the allowlist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ ehthumbs.db
 Thumbs.db
 
 *.ignore.yaml
+# Compiled binary (module name)
+/mcp-shell

--- a/README.md
+++ b/README.md
@@ -29,7 +29,16 @@ mcp-shell
 
 ## Configure it
 
-Security is off by default. To enable it, point to a YAML config:
+**Secure mode is the default.** With no config file, `mcp-shell` boots in secure
+mode restricted to a narrow allowlist of read-only utilities (`ls`, `cat`,
+`grep`, `find`, `head`, `tail`, ...). You only need a config file to widen or
+change that policy. To run fully unrestricted you must opt in explicitly:
+
+```bash
+MCP_SHELL_ALLOW_UNSAFE=true mcp-shell   # disables all validation - do not use in production
+```
+
+To customize the policy, point to a YAML config:
 
 ```bash
 export MCP_SHELL_SEC_CONFIG_FILE=/path/to/security.yaml
@@ -48,7 +57,10 @@ security:
     - grep
     - find
     - echo
-    - /usr/bin/git
+  # WARNING: never add shell/language interpreters (bash, sh, python, perl,
+  # ruby, node) or alias-capable tools (git) here - the interpreter executes
+  # whatever it is handed, bypassing secure mode entirely. mcp-shell warns at
+  # startup if it finds one.
   blocked_patterns:          # optional: restrict args on allowed commands
     - '(^|\s)remote\s+(-v|--verbose)(\s|$)'
   max_execution_time: 30s
@@ -113,7 +125,8 @@ Response includes `status`, `exit_code`, `stdout`, `stderr`, `command`, `executi
 
 | Variable | Description |
 |----------|-------------|
-| `MCP_SHELL_SEC_CONFIG_FILE` | Path to security YAML |
+| `MCP_SHELL_SEC_CONFIG_FILE` | Path to security YAML (overrides built-in secure defaults) |
+| `MCP_SHELL_ALLOW_UNSAFE` | Set `true` to disable all validation and run unrestricted (opt-in) |
 | `MCP_SHELL_SERVER_NAME` | Server name (default: "mcp-shell 🐚") |
 | `MCP_SHELL_LOG_LEVEL` | debug, info, warn, error, fatal |
 | `MCP_SHELL_LOG_FORMAT` | json, console |
@@ -134,9 +147,10 @@ make release            # binary + docker image
 
 ## Security
 
-- **Default**: No restrictions. Commands run with full access. Fine for local dev; dangerous otherwise.
-- **Secure mode** (`use_shell_execution: false`): Executable allowlist, no shell parsing. Blocks injection.
-- **Docker**: Runs as non-root, Alpine-based. Use it in production.
+- **Default**: Secure mode, restricted to a narrow allowlist of read-only utilities. No interpreters.
+- **Secure mode** (`use_shell_execution: false`): Executable allowlist, no shell parsing. Blocks injection. Never allowlist interpreters (bash/sh/python/git) — doing so defeats the allowlist.
+- **Unrestricted**: Only via `MCP_SHELL_ALLOW_UNSAFE=true`. Full access; fine for local dev, dangerous otherwise.
+- **Docker**: Runs as non-root, Alpine-based. Use it in production. Best paired with an OS sandbox (read-only FS, dropped caps) as defense-in-depth.
 
 ---
 

--- a/config.go
+++ b/config.go
@@ -17,17 +17,17 @@ type Config struct {
 }
 
 type SecurityConfig struct {
-	Enabled          bool          `yaml:"enabled"`
-	AllowedCommands  []string      `yaml:"allowed_commands"`      // Deprecated: use AllowedExecutables
-	BlockedCommands  []string      `yaml:"blocked_commands"`      // Deprecated: use validation instead
-	BlockedPatterns  []string      `yaml:"blocked_patterns"`      // Deprecated: use validation instead
-	AllowedExecutables []string    `yaml:"allowed_executables"`   // Secure: list of allowed executable paths
-	MaxExecutionTime time.Duration `yaml:"max_execution_time"`
-	WorkingDirectory string        `yaml:"working_directory"`
-	RunAsUser        string        `yaml:"run_as_user"`
-	MaxOutputSize    int           `yaml:"max_output_size"`
-	AuditLog         bool          `yaml:"audit_log"`
-	UseShellExecution bool         `yaml:"use_shell_execution"`   // Legacy mode - enables shell execution (DANGEROUS)
+	Enabled            bool          `yaml:"enabled"`
+	AllowedCommands    []string      `yaml:"allowed_commands"`    // Deprecated: use AllowedExecutables
+	BlockedCommands    []string      `yaml:"blocked_commands"`    // Deprecated: use validation instead
+	BlockedPatterns    []string      `yaml:"blocked_patterns"`    // Deprecated: use validation instead
+	AllowedExecutables []string      `yaml:"allowed_executables"` // Secure: list of allowed executable paths
+	MaxExecutionTime   time.Duration `yaml:"max_execution_time"`
+	WorkingDirectory   string        `yaml:"working_directory"`
+	RunAsUser          string        `yaml:"run_as_user"`
+	MaxOutputSize      int           `yaml:"max_output_size"`
+	AuditLog           bool          `yaml:"audit_log"`
+	UseShellExecution  bool          `yaml:"use_shell_execution"` // Legacy mode - enables shell execution (DANGEROUS)
 }
 
 type ServerConfig struct {
@@ -41,13 +41,38 @@ type LoggingConfig struct {
 	Output string
 }
 
+// newDefaultSecurityConfig returns the built-in secure defaults applied when no
+// MCP_SHELL_SEC_CONFIG_FILE is provided. Secure mode is the operating default:
+// the server boots restricted to a narrow allowlist of utilities that cannot
+// themselves spawn arbitrary processes. Shell/language interpreters (bash, sh,
+// python, perl, ruby, git) are intentionally excluded - allowing one is
+// equivalent to disabling the allowlist entirely.
+func newDefaultSecurityConfig() SecurityConfig {
+	return SecurityConfig{
+		Enabled:           true,
+		UseShellExecution: false,
+		AllowedExecutables: []string{
+			"ls", "pwd", "whoami", "date", "echo",
+			"cat", "grep", "find", "wc", "head", "tail", "sort", "uniq",
+		},
+		MaxExecutionTime: 30 * time.Second,
+		MaxOutputSize:    1048576,
+		WorkingDirectory: "/tmp",
+		AuditLog:         true,
+	}
+}
+
 func loadConfig() (*Config, error) {
 	_ = godotenv.Load()
 
+	security := newDefaultSecurityConfig()
+	// Unrestricted mode requires affirmative opt-in, never silence.
+	if getBoolEnv("MCP_SHELL_ALLOW_UNSAFE", false) {
+		security.Enabled = false
+	}
+
 	config := &Config{
-		Security: SecurityConfig{
-			Enabled: false,
-		},
+		Security: security,
 		Server: ServerConfig{
 			Name:    getEnv("MCP_SHELL_SERVER_NAME", "mcp-shell 🐚"),
 			Version: version,
@@ -81,17 +106,17 @@ func loadSecurityFromFile(config *Config, filename string) error {
 
 	var yamlConfig struct {
 		Security struct {
-			Enabled          bool     `yaml:"enabled"`
-			AllowedCommands  []string `yaml:"allowed_commands"`
-			BlockedCommands  []string `yaml:"blocked_commands"`
-			BlockedPatterns  []string `yaml:"blocked_patterns"`
+			Enabled            bool     `yaml:"enabled"`
+			AllowedCommands    []string `yaml:"allowed_commands"`
+			BlockedCommands    []string `yaml:"blocked_commands"`
+			BlockedPatterns    []string `yaml:"blocked_patterns"`
 			AllowedExecutables []string `yaml:"allowed_executables"`
-			MaxExecutionTime string   `yaml:"max_execution_time"`
-			WorkingDirectory string   `yaml:"working_directory"`
-			RunAsUser        string   `yaml:"run_as_user"`
-			MaxOutputSize    int      `yaml:"max_output_size"`
-			AuditLog         bool     `yaml:"audit_log"`
-			UseShellExecution bool    `yaml:"use_shell_execution"`
+			MaxExecutionTime   string   `yaml:"max_execution_time"`
+			WorkingDirectory   string   `yaml:"working_directory"`
+			RunAsUser          string   `yaml:"run_as_user"`
+			MaxOutputSize      int      `yaml:"max_output_size"`
+			AuditLog           bool     `yaml:"audit_log"`
+			UseShellExecution  bool     `yaml:"use_shell_execution"`
 		} `yaml:"security"`
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -15,16 +15,36 @@ func TestLoadConfig_defaults(t *testing.T) {
 	os.Unsetenv("MCP_SHELL_SEC_CONFIG_FILE")
 	os.Unsetenv("MCP_SHELL_SERVER_NAME")
 	os.Unsetenv("MCP_SHELL_LOG_LEVEL")
+	os.Unsetenv("MCP_SHELL_ALLOW_UNSAFE")
 
 	config, err := loadConfig()
 	require.NoError(t, err)
 
-	// Check defaults
-	assert.False(t, config.Security.Enabled)
+	// Secure mode is the built-in default, no config file required.
+	assert.True(t, config.Security.Enabled)
+	assert.False(t, config.Security.UseShellExecution)
+	assert.NotEmpty(t, config.Security.AllowedExecutables)
+	// No shell/language interpreter ships in the default allowlist.
+	for _, exe := range config.Security.AllowedExecutables {
+		assert.False(t, isInterpreterExecutable(exe),
+			"default allowlist must not contain interpreter %q", exe)
+	}
 	assert.Equal(t, "mcp-shell 🐚", config.Server.Name)
 	assert.Equal(t, "info", config.Logging.Level)
 	assert.Equal(t, "console", config.Logging.Format)
 	assert.Equal(t, "stderr", config.Logging.Output)
+}
+
+func TestLoadConfig_allowUnsafeOptOut(t *testing.T) {
+	os.Unsetenv("MCP_SHELL_SEC_CONFIG_FILE")
+	os.Setenv("MCP_SHELL_ALLOW_UNSAFE", "true")
+	t.Cleanup(func() { os.Unsetenv("MCP_SHELL_ALLOW_UNSAFE") })
+
+	config, err := loadConfig()
+	require.NoError(t, err)
+
+	// Unrestricted mode only via affirmative opt-in.
+	assert.False(t, config.Security.Enabled)
 }
 
 func TestLoadConfig_environment_variables(t *testing.T) {
@@ -33,7 +53,7 @@ func TestLoadConfig_environment_variables(t *testing.T) {
 	os.Setenv("MCP_SHELL_LOG_LEVEL", "debug")
 	os.Setenv("MCP_SHELL_LOG_FORMAT", "json")
 	os.Setenv("MCP_SHELL_LOG_OUTPUT", "stdout")
-	
+
 	defer func() {
 		os.Unsetenv("MCP_SHELL_SERVER_NAME")
 		os.Unsetenv("MCP_SHELL_LOG_LEVEL")
@@ -138,7 +158,7 @@ security:
 			// Create temporary file
 			tmpDir := t.TempDir()
 			configFile := filepath.Join(tmpDir, "security.yaml")
-			
+
 			err := os.WriteFile(configFile, []byte(tt.yamlContent), 0644)
 			require.NoError(t, err)
 
@@ -226,7 +246,7 @@ func TestGetEnv_functions(t *testing.T) {
 		// Test with existing environment variable
 		os.Setenv("TEST_VAR", "test_value")
 		defer os.Unsetenv("TEST_VAR")
-		
+
 		value := getEnv("TEST_VAR", "default")
 		assert.Equal(t, "test_value", value)
 
@@ -239,7 +259,7 @@ func TestGetEnv_functions(t *testing.T) {
 		// Test with true value
 		os.Setenv("TEST_BOOL", "true")
 		defer os.Unsetenv("TEST_BOOL")
-		
+
 		value := getBoolEnv("TEST_BOOL", false)
 		assert.True(t, value)
 
@@ -262,7 +282,7 @@ func TestGetEnv_functions(t *testing.T) {
 		// Test with valid integer
 		os.Setenv("TEST_INT", "42")
 		defer os.Unsetenv("TEST_INT")
-		
+
 		value := getIntEnv("TEST_INT", 0)
 		assert.Equal(t, 42, value)
 
@@ -295,7 +315,7 @@ security:
 `
 		tmpDir := t.TempDir()
 		configFile := filepath.Join(tmpDir, "secure.yaml")
-		
+
 		err := os.WriteFile(configFile, []byte(yamlContent), 0644)
 		require.NoError(t, err)
 
@@ -335,7 +355,7 @@ security:
 `
 		tmpDir := t.TempDir()
 		configFile := filepath.Join(tmpDir, "legacy.yaml")
-		
+
 		err := os.WriteFile(configFile, []byte(yamlContent), 0644)
 		require.NoError(t, err)
 

--- a/main.go
+++ b/main.go
@@ -33,10 +33,13 @@ func run() error {
 	}
 
 	configFile := os.Getenv("MCP_SHELL_SEC_CONFIG_FILE")
-	if configFile != "" {
-		log.Info().Str("config_file", configFile).Msg("Loading security config")
-	} else {
-		log.Info().Msg("No security config file specified, security disabled")
+	switch {
+	case configFile != "":
+		log.Info().Str("config_file", configFile).Msg("Loading security config from file")
+	case cfg.Security.Enabled:
+		log.Info().Msg("No security config file specified, using built-in secure defaults")
+	default:
+		log.Warn().Msg("SECURITY DISABLED via MCP_SHELL_ALLOW_UNSAFE - all commands run unrestricted")
 	}
 
 	log.Info().

--- a/security.go
+++ b/security.go
@@ -16,10 +16,40 @@ type SecurityValidator struct {
 }
 
 func newSecurityValidator(cfg SecurityConfig, logger zerolog.Logger) *SecurityValidator {
-	return &SecurityValidator{
+	v := &SecurityValidator{
 		config: cfg,
 		logger: logger.With().Str("component", "security").Logger(),
 	}
+	v.warnOnInterpreters()
+	return v
+}
+
+// warnOnInterpreters flags allowlisted executables that can execute arbitrary
+// commands regardless of metacharacter checks (shell/language interpreters, and
+// git via `-c alias.x=!cmd`). Allowing one defeats secure mode; the warning
+// surfaces the misconfiguration at startup instead of silently trusting it.
+func (v *SecurityValidator) warnOnInterpreters() {
+	if !v.config.Enabled || v.config.UseShellExecution {
+		return
+	}
+	for _, exe := range v.config.AllowedExecutables {
+		if isInterpreterExecutable(filepath.Base(exe)) {
+			v.logger.Warn().
+				Str("executable", exe).
+				Msg("allowed executable can run arbitrary commands (interpreter or alias-capable) - this defeats secure mode regardless of metacharacter filtering")
+		}
+	}
+}
+
+// isInterpreterExecutable reports whether base names an executable that can
+// itself run arbitrary commands, making executable-allowlisting ineffective.
+func isInterpreterExecutable(base string) bool {
+	switch base {
+	case "bash", "sh", "zsh", "fish", "dash", "ksh", "csh", "tcsh",
+		"python", "python2", "python3", "perl", "ruby", "node", "php", "git":
+		return true
+	}
+	return false
 }
 
 func (v *SecurityValidator) validateCommand(command string) error {
@@ -133,7 +163,9 @@ func (v *SecurityValidator) matchesExecutable(executable, pattern string) bool {
 // containsShellMetacharacters checks if a string contains shell metacharacters
 // that could be used for command injection
 func containsShellMetacharacters(s string) bool {
-	metachars := "|&;<>(){}[]$`\\"
+	// '!' is included because git interprets `-c alias.x=!cmd` as a shell alias,
+	// turning an allowlisted git into arbitrary command execution.
+	metachars := "|&;<>(){}[]$`\\!"
 	for _, char := range s {
 		if strings.ContainsRune(metachars, char) {
 			return true
@@ -145,7 +177,7 @@ func containsShellMetacharacters(s string) bool {
 // containsDangerousShellConstructs checks for potentially dangerous shell constructs
 func containsDangerousShellConstructs(s string) bool {
 	dangerous := []string{
-		"$(", "`", "${", "&&", "||", ";", "|", ">", "<", ">>", "<<", "&",
+		"$(", "`", "${", "&&", "||", ";", "|", ">", "<", ">>", "<<", "&", "=!",
 	}
 	for _, construct := range dangerous {
 		if strings.Contains(s, construct) {

--- a/security.yaml
+++ b/security.yaml
@@ -10,6 +10,14 @@ security:
   
   # Allowed executables - only these commands can be executed
   # Use absolute paths for maximum security, or command names for PATH lookup
+  #
+  # WARNING: Never add shell or language interpreters (bash, sh, python, perl,
+  # ruby, node, php) or alias-capable tools (git) to this list. The interpreter
+  # executes whatever it is handed, so allowing one bypasses secure mode
+  # entirely - the metacharacter checks never see the inner command. mcp-shell
+  # logs a warning at startup if it detects one here.
+  # Note: 'find' is allowed but can itself spawn processes via -exec; restrict it
+  # with blocked_patterns if that matters for your threat model.
   allowed_executables:
     - "ls"
     - "pwd"
@@ -24,9 +32,6 @@ security:
     - "tail"
     - "sort"
     - "uniq"
-    - "/usr/bin/git"
-    - "/usr/bin/python3"
-    - "/bin/bash"  # Only allow if you trust the arguments
   
   # Legacy settings (deprecated but kept for backwards compatibility)
   # These are ignored when use_shell_execution is false

--- a/security_test.go
+++ b/security_test.go
@@ -137,6 +137,31 @@ func TestSecurityValidator_validateCommand(t *testing.T) {
 			expectError:   true,
 			errorContains: "blocked keyword",
 		},
+		// GHSA-74hp-mggr-hv58: git shell-alias bypass via `-c alias.x=!cmd`.
+		{
+			name: "secure mode blocks git shell-alias injection",
+			config: SecurityConfig{
+				Enabled:            true,
+				UseShellExecution:  false,
+				AllowedExecutables: []string{"git"},
+			},
+			command:       "git -c alias.pwn=!touch pwn /tmp/target",
+			expectError:   true,
+			errorContains: "shell metacharacters",
+		},
+		// GHSA-3x77-wg38-92r3: an interpreter still has to be in the allowlist
+		// to be reachable; bash absent from the list is rejected outright.
+		{
+			name: "secure mode blocks bash -c when bash not allowlisted",
+			config: SecurityConfig{
+				Enabled:            true,
+				UseShellExecution:  false,
+				AllowedExecutables: []string{"ls", "echo"},
+			},
+			command:       "/bin/bash -c id",
+			expectError:   true,
+			errorContains: "not in allowed list",
+		},
 	}
 
 	for _, tt := range tests {
@@ -160,11 +185,11 @@ func TestSecurityValidator_validateExecutableCommand(t *testing.T) {
 	logger := zerolog.New(zerolog.NewTestWriter(t))
 
 	tests := []struct {
-		name              string
+		name               string
 		allowedExecutables []string
-		command           string
-		expectError       bool
-		errorContains     string
+		command            string
+		expectError        bool
+		errorContains      string
 	}{
 		{
 			name:               "simple command in allowlist",
@@ -282,11 +307,11 @@ func TestSecurityValidator_validateLegacyCommand(t *testing.T) {
 	logger := zerolog.New(zerolog.NewTestWriter(t))
 
 	tests := []struct {
-		name            string
-		config          SecurityConfig
-		command         string
-		expectError     bool
-		errorContains   string
+		name          string
+		config        SecurityConfig
+		command       string
+		expectError   bool
+		errorContains string
 	}{
 		{
 			name: "no restrictions - allows everything",


### PR DESCRIPTION
## Why

Three security advisories (and issue #13) showed that mcp-shell's "secure mode" did not deliver the restriction it advertises along either documented install path:

- **`GHSA-f5pj-2738-996m` (critical)** — the bare binary shipped with `Security.Enabled=false`, so the from-source install in the README ran an **unrestricted shell**.
- **`GHSA-3x77-wg38-92r3` / `GHSA-74hp-mggr-hv58` (high)** — the default `security.yaml` allowlisted `/bin/bash`, `/usr/bin/python3` and `/usr/bin/git`. Allowlisting an interpreter is equivalent to disabling the allowlist (`bash -c`, `python3 payload.py`, `git -c alias.x=!cmd`).
- **`GHSA-74hp`** also relied on `!` being absent from the metacharacter blocklist (git shell-alias bypass).

## What changed

- **Secure by default.** `newDefaultSecurityConfig()` boots the server in secure mode restricted to a narrow allowlist of read-only utilities — no config file required. Unrestricted mode now requires an explicit `MCP_SHELL_ALLOW_UNSAFE=true` opt-in.
- **No interpreters in the default `security.yaml`** (dropped `bash`/`python3`/`git`) + a startup **warning** if an interpreter or alias-capable tool is found in any allowlist.
- **Block `!` / `=!`** as shell metacharacters / dangerous constructs (closes the git-alias bypass).
- Fixed the misleading `"security disabled"` startup log.
- README + env-var table + tests.

The Docker image inherits the sanitized `security.yaml` via the existing `COPY`.

## Out of scope (follow-up)

Real command unfurling of `bash -c` / git aliases and per-argument policy — tracked separately.

## Test

`go build ./... && go vet ./... && go test ./...` — green. New cases cover the git-alias bypass, `bash -c` rejection, the embedded secure default, and the `MCP_SHELL_ALLOW_UNSAFE` opt-out.