### PR TITLE
ci: run build, vet and tests on push and PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test -race ./...


### PR DESCRIPTION
## What

Adds a `CI` workflow that runs on every push to `master` and every pull request:

- `go build ./...`
- `go vet ./...`
- `go test -race ./...`

`go-version-file: go.mod` so the toolchain follows the `go` directive automatically (handy alongside #17, which bumps it to 1.26).

## Scope note

Lint / `gofmt` gating is intentionally left out for now — a couple of pre-existing test files (`executor_test.go`, `handler_test.go`) aren't gofmt-clean, so a formatting gate would fail red on master. Easy to add once those are formatted.

Closes the gap where #17 and #18 could merge with no automated verification.