### PR TITLE
ci: allow manual dispatch of release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,7 @@ name: Release Please
 on:
   push:
     branches: [master]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger so the release-please workflow can be run manually (e.g. to re-evaluate the release PR) without pushing to master.