### PR TITLE
Harden secure mode: deny-by-default classification plus env, git, and config fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,11 @@ security:
     - grep
     - find
     - echo
-  # WARNING: never add shell/language interpreters (bash, sh, python, perl,
-  # ruby, node) or alias-capable tools (git) here - the interpreter executes
-  # whatever it is handed, bypassing secure mode entirely. mcp-shell warns at
-  # startup if it finds one.
+  # Allowlisting is necessary but not sufficient: an executable also has to be
+  # classified as safe (a known data-only utility, or governed by an argument
+  # policy like git/find/sort/uniq). Interpreters (bash, python, ...) and
+  # command wrappers (env, timeout, nice, xargs, ...) are unclassified and get
+  # rejected even if listed here; mcp-shell warns at startup about dead entries.
   blocked_patterns:          # optional: restrict args on allowed commands
     - '(^|\s)remote\s+(-v|--verbose)(\s|$)'
   max_execution_time: 30s
@@ -148,9 +149,11 @@ make release            # binary + docker image
 ## Security
 
 - **Default**: Secure mode, restricted to a narrow allowlist of read-only utilities. No interpreters.
-- **Secure mode** (`use_shell_execution: false`): the command is parsed into a shell AST and only a single, fully-literal simple command is accepted (no pipes, lists, substitution, redirection or globs); its executable must be on the allowlist. Interpreters (bash/sh/python) are hard-denied even if allowlisted, and per-tool policies are deny-by-default: for governed binaries (`git`, `find`, `sort`, `tar`) only explicitly safe flags are accepted and everything else, including unknown or future escape-hatch flags, is rejected (`git -c`/`config`, `find -exec`/`-fls`, `sort -o`/`--compress-program`, `tar -I`/`-C`). Git is limited to read-only subcommands. This is an early-reject layer, not a sandbox.
+- **Secure mode** (`use_shell_execution: false`): the command is parsed into a shell AST and only a single, fully-literal simple command is accepted (no pipes, lists, substitution, redirection or globs); its executable must be on the allowlist **and** be classified as safe: either a known data-only utility (`ls`, `cat`, `grep`, ...) or governed by a deny-by-default argument policy (`git`, `find`, `sort`, `uniq`), where only explicitly safe flags are accepted (`git -c`/`config`, `find -exec`/`-fls`, `sort -o`/`--compress-program` are rejected). Anything unclassified - interpreters, command wrappers like `env`/`timeout`/`xargs`, `tar`, or any other binary - is rejected even when allowlisted. Git is limited to read-only subcommands, run with the diff and textconv drivers suppressed and a minimal environment. The child inherits no server or `.env` secrets. This is an early-reject layer, not a sandbox.
 - **Unrestricted**: Only via `MCP_SHELL_ALLOW_UNSAFE=true`. Full access; fine for local dev, dangerous otherwise.
 - **Docker**: Runs as non-root, Alpine-based. Use it in production. Best paired with an OS sandbox (read-only FS, dropped caps) as defense-in-depth.
+
+Threat model, guarantees, and the scope for vulnerability reports live in [SECURITY.md](SECURITY.md). Read it before opening an advisory.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,82 @@
+# Security Policy
+
+## Threat model
+
+`mcp-shell` executes commands on behalf of an untrusted MCP client (typically
+an LLM that may be prompt-injected). Secure mode is an **early-reject layer**:
+it refuses commands it cannot affirmatively classify as safe. It is **not a
+sandbox** and does not claim to contain a process once it runs.
+
+What secure mode guarantees (with `use_shell_execution: false`):
+
+- Only a single, fully-literal simple command is accepted. Pipes, lists,
+  substitution, redirection, globs and any other shell structure are rejected
+  at the AST level.
+- The executable must be on the operator's allowlist **and** be classified as
+  safe. Classified means one of:
+  - a **data-only utility**: transforms or reports data, cannot execute other
+    programs, cannot write to a caller-chosen path (`ls`, `cat`, `grep`, ...);
+  - a **policy-governed binary**: `git`, `find`, `sort`, `uniq`, whose
+    arguments are checked deny-by-default so only explicitly safe flags pass.
+- Everything else is rejected, even when allowlisted. There is no denylist of
+  "dangerous binaries" to bypass: interpreters (`bash`, `python`, ...),
+  command wrappers (`env`, `timeout`, `nice`, `xargs`, `busybox`, ...) and any
+  binary the classifier does not know are all denied by construction.
+- The executable is run with a **minimal environment**, not the server's. The
+  process environment and any `.env` loaded at startup are not inherited, so an
+  allowlisted reader (`cat /proc/self/environ`, `env`) cannot read secrets held
+  by the server or exported by the MCP client.
+- A relative `argv[0]` containing a path separator (`./ls`, `sub/ls`) is
+  rejected: only a bare name resolved via `PATH` or an absolute path is
+  accepted, so validation and execution cannot resolve different files.
+
+What secure mode does **not** guarantee:
+
+- It is not an OS sandbox. It does not confine filesystem, network or resource
+  usage of a command once accepted. Real containment comes from the deployment:
+  run the provided Docker image (non-root), ideally with a read-only rootfs,
+  dropped capabilities and no network, or an equivalent OS-level sandbox.
+- Legacy mode (`use_shell_execution: true`) is best-effort string filtering,
+  documented as vulnerable to injection. It exists for backwards compatibility
+  and carries no bypass-resistance claim.
+- `MCP_SHELL_ALLOW_UNSAFE=true` disables all checks by explicit opt-in.
+- **git can still mutate refs within its own repository.** The allowed git
+  subcommands do not execute programs, write outside the repo or reach the
+  network - `core.fsmonitor`, `diff.external` and per-path `textconv` drivers
+  are all suppressed, and system/global config is neutralised. But `branch`,
+  `tag`, `symbolic-ref` and `reflog` can still delete or move refs in the
+  repository git runs in. That is bounded to the repo (no arbitrary-path write,
+  no execution) and is a known, lower-severity gap. If even repo-local mutation
+  is unacceptable, run git under a read-only OS sandbox.
+
+## Scope for vulnerability reports
+
+In scope (please report):
+
+- A command that executes a program, writes to a caller-chosen path, or
+  reaches the network despite passing secure-mode validation with the
+  **default configuration**.
+- A data-only classified utility that can in fact execute programs or write to
+  caller-chosen paths (a misclassification).
+- An argument-policy escape: a governed binary (`git`, `find`, `sort`, `uniq`)
+  accepting a flag or form that executes programs or writes to caller-chosen
+  paths.
+- Bypasses of the AST structural check (smuggling shell structure through the
+  unfurler).
+
+Out of scope (known limitations, not vulnerabilities):
+
+- Anything requiring `use_shell_execution: true`, `enabled: false` or
+  `MCP_SHELL_ALLOW_UNSAFE=true`.
+- Resource exhaustion, information disclosure or filesystem reads by
+  data-only utilities within the working directory contract (`cat` reading a
+  readable file is what `cat` is for). Confinement is the sandbox's job.
+- Reports that amount to "the operator can write an unsafe config" without a
+  bypass of the classification described above.
+
+## Reporting
+
+Use GitHub private vulnerability reporting on this repository. Include a
+runnable proof of concept against the default configuration or a minimal
+config diff. Reports matching the in-scope list are triaged and credited;
+out-of-scope reports are closed with a pointer to this document.

--- a/argpolicy.go
+++ b/argpolicy.go
@@ -30,7 +30,10 @@ func newPolicySet(policies ...argPolicy) *policySet {
 }
 
 func newDefaultPolicySet() *policySet {
-	return newPolicySet(newGitArgPolicy(), newFindArgPolicy(), newTarArgPolicy(), newSortArgPolicy())
+	return newPolicySet(
+		newGitArgPolicy(), newFindArgPolicy(), newSortArgPolicy(),
+		newUniqArgPolicy(),
+	)
 }
 
 // governs reports whether a policy exists for the executable's basename.
@@ -131,9 +134,13 @@ var gitAllowedGlobal = newStringSet(
 	"--literal-pathspecs", "--no-optional-locks",
 )
 
-// gitAllowedSubcommands are read-only: they cannot mutate refs, the working
-// tree, config, or reach the network. --git-dir/--work-tree are deliberately
-// not allowed globals, so these cannot be retargeted at an arbitrary path.
+// gitAllowedSubcommands neither execute programs, write outside the repository,
+// nor reach the network. --git-dir/--work-tree are deliberately not allowed
+// globals, so none can be retargeted at an arbitrary path. They are not all
+// strictly read-only: branch, tag, symbolic-ref and reflog can still mutate refs
+// within the repository. That is bounded to the repo (no arbitrary-path write,
+// no execution) and is a lower-severity gap left open on purpose; the diff and
+// textconv drivers, which do execute programs, are suppressed in the executor.
 var gitAllowedSubcommands = newStringSet(
 	"status", "log", "show", "diff", "branch", "tag", "describe",
 	"rev-parse", "rev-list", "ls-files", "ls-tree", "cat-file", "blame",
@@ -144,12 +151,13 @@ var gitAllowedSubcommands = newStringSet(
 
 // gitDeniedFlag reports flags that are dangerous under any allowed subcommand:
 // --output (diff/log/show write to an arbitrary file), --ext-diff (runs
-// diff.external), --open-files-in-pager (runs the pager as a command), and
-// --contents (blame reads an arbitrary file into the output). All are long
+// diff.external), --open-files-in-pager (runs the pager as a command),
+// --contents (blame reads an arbitrary file into the output), and --textconv
+// (cat-file/blame/log run a repo-configured textconv program). All are long
 // forms, so an exact/prefix name test suffices - git does not bundle these.
 func gitDeniedFlag(tok string) bool {
 	switch longFlagName(tok) {
-	case "--output", "--open-files-in-pager", "--ext-diff", "--contents":
+	case "--output", "--open-files-in-pager", "--ext-diff", "--contents", "--textconv":
 		return true
 	}
 	return false
@@ -271,78 +279,67 @@ func (*sortArgPolicy) check(argv []string) error {
 	return nil
 }
 
-// tarArgPolicy allowlists tar's archive-operation flags. -I/--use-compress-program
-// and the checkpoint/remote-shell hooks execute arbitrary programs; everything
-// else unlisted fails closed too.
-type tarArgPolicy struct{}
+// uniqArgPolicy allowlists uniq's comparison/formatting flags and denies a
+// second positional operand: `uniq input output` writes to an arbitrary file,
+// the same escape-hatch class as find -fls and sort -o. Separate-value flags
+// (-f 2, --skip-fields 2) consume their value so it is not miscounted as an
+// operand.
+type uniqArgPolicy struct{}
 
-func newTarArgPolicy() *tarArgPolicy { return &tarArgPolicy{} }
+func newUniqArgPolicy() *uniqArgPolicy { return &uniqArgPolicy{} }
 
-func (*tarArgPolicy) name() string { return "tar" }
+func (*uniqArgPolicy) name() string { return "uniq" }
 
 var (
-	// -C (arg-taking) and -p are consumed but not allowed: -C relocates the
-	// extraction/archive root outside the sandbox working dir, and -p restores
-	// setuid/setgid bits from an attacker-supplied archive.
-	tarAllowedShort = newByteSet("cxtruvzjJfkmOSw")
-	tarArgTaking    = newByteSet("fCTXbIKNLVg")
-	tarAllowedLong  = newStringSet(
-		"--create", "--extract", "--list", "--append", "--update", "--verbose",
-		"--gzip", "--bzip2", "--xz", "--file", "--exclude",
-		"--exclude-from", "--no-same-owner", "--keep-old-files", "--to-stdout",
-		"--strip-components", "--wildcards", "--anchored", "--numeric-owner",
-		"--owner", "--group", "--mode", "--help", "--version",
+	uniqAllowedShort = newByteSet("cdDiuzfsw")
+	uniqArgTaking    = newByteSet("fsw")
+	uniqAllowedLong  = newStringSet(
+		"--count", "--repeated", "--all-repeated", "--ignore-case", "--unique",
+		"--zero-terminated", "--group", "--skip-fields", "--skip-chars",
+		"--check-chars", "--help", "--version",
 	)
+	// Long flags whose value may arrive as the next token instead of =value.
+	uniqLongValueSeparate = newStringSet("--skip-fields", "--skip-chars", "--check-chars")
 )
 
-func tarRejectLetter(c byte, tok string) error {
-	switch c {
-	case 'I':
-		return fmt.Errorf("tar: %q can execute arbitrary programs and is not allowed in secure mode", tok)
-	case 'C':
-		return fmt.Errorf("tar: %q relocates the archive root outside the sandbox and is not allowed in secure mode", tok)
-	case 'p':
-		return fmt.Errorf("tar: %q restores setuid bits from the archive and is not allowed in secure mode", tok)
-	}
-	return fmt.Errorf("tar: %q is not allowed in secure mode", tok)
+func uniqRejectLetter(_ byte, tok string) error {
+	return fmt.Errorf("uniq: %q is not allowed in secure mode", tok)
 }
 
-func (*tarArgPolicy) check(argv []string) error {
-	// tar's historic bundled form puts the function letters in the first word
-	// with no leading dash ("tar xzf a.tar" == "tar -xzf a.tar"). Such a token
-	// fails isFlagToken and would otherwise skip checkShortCluster entirely, so
-	// "tar xfC a.tar /dst" would smuggle -C past the policy. Validate the first
-	// word letter by letter here. Unlike getopt clusters, every letter is an
-	// option (its value comes from a later word), so there is no arg-taking stop.
-	if len(argv) > 1 && len(argv[1]) > 0 && argv[1][0] != '-' {
-		for i := 0; i < len(argv[1]); i++ {
-			if c := argv[1][i]; !tarAllowedShort.has(c) {
-				return tarRejectLetter(c, argv[1])
-			}
-		}
-	}
+func (*uniqArgPolicy) check(argv []string) error {
+	operands := 0
+	expectValue := false
+	optionsEnded := false
 	for _, a := range argv[1:] {
-		if !isFlagToken(a) {
+		if expectValue {
+			expectValue = false
 			continue
 		}
-		if strings.HasPrefix(a, "--") {
-			name := longFlagName(a)
-			if tarAllowedLong.has(name) {
+		if !optionsEnded && a == "--" {
+			optionsEnded = true
+			continue
+		}
+		if !optionsEnded && isFlagToken(a) {
+			if strings.HasPrefix(a, "--") {
+				name := longFlagName(a)
+				if !uniqAllowedLong.has(name) {
+					return fmt.Errorf("uniq: %q is not allowed in secure mode", a)
+				}
+				// Bare form ("--skip-fields 2"): the next token is the value.
+				expectValue = uniqLongValueSeparate.has(name) && name == a
 				continue
 			}
-			switch name {
-			case "--to-command", "--checkpoint-action", "--use-compress-program", "--rsh-command":
-				return fmt.Errorf("tar: %q can execute arbitrary programs and is not allowed in secure mode", a)
-			case "--directory":
-				return fmt.Errorf("tar: %q relocates the archive root outside the sandbox and is not allowed in secure mode", a)
-			case "--preserve-permissions", "--same-permissions":
-				return fmt.Errorf("tar: %q restores setuid bits from the archive and is not allowed in secure mode", a)
-			default:
-				return fmt.Errorf("tar: %q is not allowed in secure mode", a)
+			if err := checkShortCluster(a, uniqAllowedShort, uniqArgTaking, uniqRejectLetter); err != nil {
+				return err
 			}
+			// A cluster ending exactly on a value-taking letter ("-f") takes its
+			// value from the next token; a glued value ("-f2") does not.
+			expectValue = uniqArgTaking.has(a[len(a)-1])
+			continue
 		}
-		if err := checkShortCluster(a, tarAllowedShort, tarArgTaking, tarRejectLetter); err != nil {
-			return err
+		operands++
+		if operands > 1 {
+			return fmt.Errorf("uniq: %q names an output file, which writes to an arbitrary path and is not allowed in secure mode", a)
 		}
 	}
 	return nil

--- a/argpolicy_test.go
+++ b/argpolicy_test.go
@@ -43,6 +43,12 @@ func TestPolicySet_check(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name:          "git cat-file --textconv blocked",
+			argv:          []string{"git", "cat-file", "--textconv", "HEAD:a.txt"},
+			expectError:   true,
+			errorContains: "not allowed",
+		},
+		{
 			name:          "find -exec blocked",
 			argv:          []string{"find", ".", "-exec", "rm", "{}", "+"},
 			expectError:   true,
@@ -96,25 +102,41 @@ func TestPolicySet_check(t *testing.T) {
 			errorContains: "arbitrary file",
 		},
 		{
-			name:        "sort plain sort allowed",
-			argv:        []string{"sort", "-n", "-r", "-k2", "f"},
+			name:          "uniq second operand arbitrary write blocked",
+			argv:          []string{"uniq", "input.txt", "/tmp/pwned"},
+			expectError:   true,
+			errorContains: "output file",
+		},
+		{
+			name:          "uniq second operand after -- blocked",
+			argv:          []string{"uniq", "--", "input.txt", "/tmp/pwned"},
+			expectError:   true,
+			errorContains: "output file",
+		},
+		{
+			name:          "uniq unknown flag blocked",
+			argv:          []string{"uniq", "-t", "input.txt"},
+			expectError:   true,
+			errorContains: "not allowed",
+		},
+		{
+			name:        "uniq single input allowed",
+			argv:        []string{"uniq", "-c", "input.txt"},
 			expectError: false,
 		},
 		{
-			name:          "tar checkpoint-action blocked",
-			argv:          []string{"tar", "-cf", "/dev/null", "x", "--checkpoint-action=exec=sh"},
-			expectError:   true,
-			errorContains: "checkpoint-action",
+			name:        "uniq -f separate value not miscounted as operand",
+			argv:        []string{"uniq", "-f", "2", "input.txt"},
+			expectError: false,
 		},
 		{
-			name:          "tar to-command blocked",
-			argv:          []string{"tar", "--to-command=sh", "-xf", "a.tar"},
-			expectError:   true,
-			errorContains: "to-command",
+			name:        "uniq --skip-fields separate value not miscounted as operand",
+			argv:        []string{"uniq", "--skip-fields", "2", "input.txt"},
+			expectError: false,
 		},
 		{
-			name:        "tar list allowed",
-			argv:        []string{"tar", "-tf", "a.tar"},
+			name:        "sort plain sort allowed",
+			argv:        []string{"sort", "-n", "-r", "-k2", "f"},
 			expectError: false,
 		},
 		{
@@ -174,23 +196,6 @@ func TestPolicySet_check(t *testing.T) {
 		{
 			name:        "sort -S buffer allowed",
 			argv:        []string{"sort", "-S", "1G", "f"},
-			expectError: false,
-		},
-		{
-			name:          "tar unknown flag blocked",
-			argv:          []string{"tar", "--frobnicate", "-xf", "a.tar"},
-			expectError:   true,
-			errorContains: "not allowed",
-		},
-		{
-			name:          "tar -I compress program blocked",
-			argv:          []string{"tar", "-I", "/bin/sh", "-xf", "a.tar"},
-			expectError:   true,
-			errorContains: "execute arbitrary",
-		},
-		{
-			name:        "tar bundled -xzf allowed",
-			argv:        []string{"tar", "-xzf", "a.tar"},
 			expectError: false,
 		},
 		{
@@ -258,52 +263,6 @@ func TestPolicySet_check(t *testing.T) {
 			argv:        []string{"sort", "-t", ":", "-k2", "f"},
 			expectError: false,
 		},
-		{
-			name:          "tar -C extraction escape blocked",
-			argv:          []string{"tar", "-x", "-f", "a.tar", "-C", "/etc"},
-			expectError:   true,
-			errorContains: "sandbox",
-		},
-		{
-			name:          "tar -p setuid restore blocked",
-			argv:          []string{"tar", "-xpf", "a.tar"},
-			expectError:   true,
-			errorContains: "setuid",
-		},
-		{
-			name:          "tar --directory long blocked",
-			argv:          []string{"tar", "-xf", "a.tar", "--directory=/etc"},
-			expectError:   true,
-			errorContains: "sandbox",
-		},
-		{
-			name:          "tar old-style bundled -C escape blocked",
-			argv:          []string{"tar", "xfC", "a.tar", "/tmp/dest"},
-			expectError:   true,
-			errorContains: "sandbox",
-		},
-		{
-			name:          "tar old-style bundled -p setuid blocked",
-			argv:          []string{"tar", "xfp", "a.tar"},
-			expectError:   true,
-			errorContains: "setuid",
-		},
-		{
-			name:          "tar old-style bundled -I exec blocked",
-			argv:          []string{"tar", "cIf", "/bin/sh", "out.tar", "x"},
-			expectError:   true,
-			errorContains: "execute arbitrary",
-		},
-		{
-			name:        "tar old-style xzf allowed",
-			argv:        []string{"tar", "xzf", "a.tar.gz"},
-			expectError: false,
-		},
-		{
-			name:        "tar old-style tvf allowed",
-			argv:        []string{"tar", "tvf", "a.tar"},
-			expectError: false,
-		},
 	}
 
 	policies := newDefaultPolicySet()
@@ -333,11 +292,14 @@ func TestPolicySet_governs(t *testing.T) {
 		assert.True(t, policies.governs("git"))
 		assert.True(t, policies.governs("/usr/bin/git"))
 		assert.True(t, policies.governs("find"))
-		assert.True(t, policies.governs("tar"))
+		assert.True(t, policies.governs("sort"))
+		assert.True(t, policies.governs("uniq"))
 	})
 
 	t.Run("ungoverned", func(t *testing.T) {
 		assert.False(t, policies.governs("ls"))
 		assert.False(t, policies.governs("/bin/bash"))
+		// tar is deliberately not classified: its useful modes all write files.
+		assert.False(t, policies.governs("tar"))
 	})
 }

--- a/config.go
+++ b/config.go
@@ -44,9 +44,9 @@ type LoggingConfig struct {
 // newDefaultSecurityConfig returns the built-in secure defaults applied when no
 // MCP_SHELL_SEC_CONFIG_FILE is provided. Secure mode is the operating default:
 // the server boots restricted to a narrow allowlist of utilities that cannot
-// themselves spawn arbitrary processes. Shell/language interpreters (bash, sh,
-// python, perl, ruby, git) are intentionally excluded - allowing one is
-// equivalent to disabling the allowlist entirely.
+// themselves spawn arbitrary processes. Every entry is classified as safe
+// (data-only, or governed by an argument policy); unclassified executables
+// would be rejected by secure mode anyway, so none ship here.
 func newDefaultSecurityConfig() SecurityConfig {
 	return SecurityConfig{
 		Enabled:           true,
@@ -91,6 +91,13 @@ func loadConfig() (*Config, error) {
 		}
 	}
 
+	// Disabling security must be an affirmative choice, never a side effect of a
+	// config file. Whether it comes from the env opt-out or an explicit
+	// `enabled: false`, it is only honoured alongside MCP_SHELL_ALLOW_UNSAFE.
+	if !config.Security.Enabled && !getBoolEnv("MCP_SHELL_ALLOW_UNSAFE", false) {
+		return nil, fmt.Errorf("security is disabled but MCP_SHELL_ALLOW_UNSAFE is not set; refusing to start unrestricted")
+	}
+
 	if err := validateConfig(config); err != nil {
 		return nil, fmt.Errorf("invalid configuration: %w", err)
 	}
@@ -119,6 +126,22 @@ func loadSecurityFromFile(config *Config, filename string) error {
 			UseShellExecution  bool     `yaml:"use_shell_execution"`
 		} `yaml:"security"`
 	}
+
+	// Seed the decode target with the current secure defaults so keys the file
+	// omits keep those defaults instead of decoding to zero values. Otherwise a
+	// file that only narrows the allowlist would silently set enabled=false,
+	// max_output_size=0 (unlimited) and working_directory="" - failing open.
+	sec := config.Security
+	yamlConfig.Security.Enabled = sec.Enabled
+	yamlConfig.Security.AllowedCommands = sec.AllowedCommands
+	yamlConfig.Security.BlockedCommands = sec.BlockedCommands
+	yamlConfig.Security.BlockedPatterns = sec.BlockedPatterns
+	yamlConfig.Security.AllowedExecutables = sec.AllowedExecutables
+	yamlConfig.Security.WorkingDirectory = sec.WorkingDirectory
+	yamlConfig.Security.RunAsUser = sec.RunAsUser
+	yamlConfig.Security.MaxOutputSize = sec.MaxOutputSize
+	yamlConfig.Security.AuditLog = sec.AuditLog
+	yamlConfig.Security.UseShellExecution = sec.UseShellExecution
 
 	if err := yaml.Unmarshal(data, &yamlConfig); err != nil {
 		return err

--- a/config_test.go
+++ b/config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -24,10 +25,12 @@ func TestLoadConfig_defaults(t *testing.T) {
 	assert.True(t, config.Security.Enabled)
 	assert.False(t, config.Security.UseShellExecution)
 	assert.NotEmpty(t, config.Security.AllowedExecutables)
-	// No shell/language interpreter ships in the default allowlist.
+	// Every default allowlist entry is classified as safe, so the built-in
+	// config never ships an executable that secure mode would then reject.
+	validator := newSecurityValidator(config.Security, zerolog.Nop())
 	for _, exe := range config.Security.AllowedExecutables {
-		assert.False(t, isInterpreterExecutable(exe),
-			"default allowlist must not contain interpreter %q", exe)
+		assert.True(t, validator.isClassifiedExecutable(exe),
+			"default allowlist entry %q must be data-only or policy-governed", exe)
 	}
 	assert.Equal(t, "mcp-shell 🐚", config.Server.Name)
 	assert.Equal(t, "info", config.Logging.Level)
@@ -169,6 +172,55 @@ security:
 			}
 		})
 	}
+}
+
+func TestLoadSecurityFromFile_failsClosed(t *testing.T) {
+	writeConfig := func(t *testing.T, yamlContent string) {
+		tmpDir := t.TempDir()
+		configFile := filepath.Join(tmpDir, "security.yaml")
+		require.NoError(t, os.WriteFile(configFile, []byte(yamlContent), 0o644))
+		t.Setenv("MCP_SHELL_SEC_CONFIG_FILE", configFile)
+		t.Setenv("MCP_SHELL_ALLOW_UNSAFE", "")
+	}
+
+	t.Run("omitted enabled keeps secure defaults", func(t *testing.T) {
+		// A file that only narrows the allowlist must not silently disable
+		// security: absent keys keep their secure defaults, not zero values.
+		writeConfig(t, `
+security:
+  allowed_executables:
+    - "ls"
+`)
+		config, err := loadConfig()
+		require.NoError(t, err)
+
+		assert.True(t, config.Security.Enabled)
+		assert.Equal(t, "/tmp", config.Security.WorkingDirectory)
+		assert.Equal(t, 1048576, config.Security.MaxOutputSize)
+	})
+
+	t.Run("explicit enabled false without opt-in refuses to start", func(t *testing.T) {
+		writeConfig(t, `
+security:
+  enabled: false
+  allowed_executables:
+    - "ls"
+`)
+		_, err := loadConfig()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "MCP_SHELL_ALLOW_UNSAFE")
+	})
+
+	t.Run("explicit enabled false with opt-in is allowed", func(t *testing.T) {
+		writeConfig(t, `
+security:
+  enabled: false
+`)
+		t.Setenv("MCP_SHELL_ALLOW_UNSAFE", "true")
+		config, err := loadConfig()
+		require.NoError(t, err)
+		assert.False(t, config.Security.Enabled)
+	})
 }
 
 func TestValidateConfig(t *testing.T) {

--- a/executor.go
+++ b/executor.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"os/user"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -83,6 +84,11 @@ func (e *CommandExecutor) executeSecureCommand(
 	command string,
 	useBase64 bool,
 ) (*ExecutionResult, error) {
+	// A cancellable context lets a capped output buffer stop the child the moment
+	// it overflows, instead of letting it fill memory until MaxExecutionTime.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	var cmd *exec.Cmd
 
 	// Use secure execution unless legacy shell mode is explicitly enabled
@@ -99,12 +105,18 @@ func (e *CommandExecutor) executeSecureCommand(
 			return nil, fmt.Errorf("command parsing failed: %s", res.Reason)
 		}
 
+		argv := res.Argv
+		if filepath.Base(argv[0]) == "git" {
+			argv = hardenGitArgv(argv)
+		}
+
 		e.logger.Debug().
-			Str("executable", res.Argv[0]).
-			Strs("args", res.Argv[1:]).
+			Str("executable", argv[0]).
+			Strs("args", argv[1:]).
 			Msg("Executing command with direct execution")
 
-		cmd = exec.CommandContext(ctx, res.Argv[0], res.Argv[1:]...)
+		cmd = exec.CommandContext(ctx, argv[0], argv[1:]...)
+		cmd.Env = secureChildEnv(argv[0])
 	}
 
 	if e.config.WorkingDirectory != "" {
@@ -143,19 +155,18 @@ func (e *CommandExecutor) executeSecureCommand(
 			Msg("Set process credentials")
 	}
 
-	var stdoutBuf, stderrBuf bytes.Buffer
-	cmd.Stdout = &stdoutBuf
-	cmd.Stderr = &stderrBuf
+	stdoutBuf := &cappedBuffer{max: e.config.MaxOutputSize, cancel: cancel}
+	stderrBuf := &cappedBuffer{max: e.config.MaxOutputSize, cancel: cancel}
+	cmd.Stdout = stdoutBuf
+	cmd.Stderr = stderrBuf
 
 	err := cmd.Run()
 
-	if e.config.MaxOutputSize > 0 {
-		if stdoutBuf.Len() > e.config.MaxOutputSize {
-			return nil, fmt.Errorf("stdout exceeds maximum size limit")
-		}
-		if stderrBuf.Len() > e.config.MaxOutputSize {
-			return nil, fmt.Errorf("stderr exceeds maximum size limit")
-		}
+	if stdoutBuf.overflowed {
+		return nil, fmt.Errorf("stdout exceeds maximum size limit")
+	}
+	if stderrBuf.overflowed {
+		return nil, fmt.Errorf("stderr exceeds maximum size limit")
 	}
 
 	exitCode := 0
@@ -185,4 +196,104 @@ func (e *CommandExecutor) executeSecureCommand(
 		Stderr:   stderr,
 		Command:  command,
 	}, nil
+}
+
+// cappedBuffer collects command output up to max bytes. On the first write that
+// would exceed max it keeps the prefix that fits, records the overflow and
+// cancels the command's context so the child is stopped rather than left filling
+// memory. A max of 0 means unbounded. Each buffer is written by a single
+// os/exec copy goroutine; cancel is safe to call concurrently and more than once.
+type cappedBuffer struct {
+	buf        bytes.Buffer
+	max        int
+	cancel     context.CancelFunc
+	overflowed bool
+}
+
+func (c *cappedBuffer) Write(p []byte) (int, error) {
+	if c.max > 0 {
+		if c.overflowed {
+			return len(p), nil
+		}
+		if c.buf.Len()+len(p) > c.max {
+			if remaining := c.max - c.buf.Len(); remaining > 0 {
+				c.buf.Write(p[:remaining])
+			}
+			c.overflowed = true
+			if c.cancel != nil {
+				c.cancel()
+			}
+			return len(p), nil
+		}
+	}
+	return c.buf.Write(p)
+}
+
+func (c *cappedBuffer) Bytes() []byte  { return c.buf.Bytes() }
+func (c *cappedBuffer) String() string { return c.buf.String() }
+
+// secureChildEnv builds the minimal environment for a validated child. The
+// server's own environment is never inherited, so an allowlisted reader
+// (cat /proc/self/environ, env) cannot exfiltrate secrets the MCP client or a
+// loaded .env put there. git additionally gets its system and global config
+// neutralised; repo-local config is handled by hardenGitArgv.
+func secureChildEnv(executable string) []string {
+	env := []string{
+		"PATH=" + os.Getenv("PATH"),
+		"HOME=" + os.Getenv("HOME"),
+		"LANG=C",
+	}
+	if filepath.Base(executable) == "git" {
+		env = append(env,
+			"GIT_CONFIG_NOSYSTEM=1",
+			"GIT_CONFIG_GLOBAL=/dev/null",
+		)
+	}
+	return env
+}
+
+// gitHardeningFlags are server-supplied -c overrides inserted right after the
+// git executable. core.fsmonitor runs an arbitrary program during
+// status/diff/ls-files and is disabled here; core.pager runs its value as a
+// command and is pinned to cat. The git argument policy rejects caller-supplied
+// -c, so these cannot be spoofed. Repo config an -c override cannot neutralise
+// (diff.external, per-path textconv drivers) is handled per-subcommand below.
+var gitHardeningFlags = []string{
+	"-c", "core.fsmonitor=false",
+	"-c", "core.pager=cat",
+}
+
+// gitDiffSuppressionFlags maps a git subcommand that can run a repo-configured
+// diff or textconv program to the flags that disable them. They are inserted
+// right after the subcommand token so a hostile repository's diff.external or
+// textconv driver cannot execute during an otherwise read-only command. An
+// empty diff.external cannot be set via -c (it breaks diff instead), so the
+// per-subcommand --no-ext-diff flag is the only reliable off switch. blame
+// rejects --no-ext-diff and does not run an external diff, so it takes only
+// --no-textconv.
+var gitDiffSuppressionFlags = map[string][]string{
+	"log":         {"--no-ext-diff", "--no-textconv"},
+	"diff":        {"--no-ext-diff", "--no-textconv"},
+	"show":        {"--no-ext-diff", "--no-textconv"},
+	"whatchanged": {"--no-ext-diff", "--no-textconv"},
+	"blame":       {"--no-textconv"},
+}
+
+// hardenGitArgv inserts the global -c overrides after the git executable and the
+// per-subcommand diff-suppression flags right after the subcommand token (the
+// first non-flag argument). User arguments keep their order and position, so a
+// trailing "-- <pathspec>" is unaffected.
+func hardenGitArgv(argv []string) []string {
+	hardened := make([]string, 0, len(argv)+len(gitHardeningFlags)+2)
+	hardened = append(hardened, argv[0])
+	hardened = append(hardened, gitHardeningFlags...)
+	for i, tok := range argv[1:] {
+		hardened = append(hardened, tok)
+		if !strings.HasPrefix(tok, "-") {
+			hardened = append(hardened, gitDiffSuppressionFlags[tok]...)
+			hardened = append(hardened, argv[1+i+1:]...)
+			break
+		}
+	}
+	return hardened
 }

--- a/executor_test.go
+++ b/executor_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
@@ -176,6 +177,100 @@ func TestCommandExecutor_vulnerability_prevention(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestCommandExecutor_childEnvIsMinimal(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+	ctx := context.Background()
+
+	// A secret in the server's own environment must not reach the child, or an
+	// allowlisted reader (`env`, `cat /proc/self/environ`) exfiltrates it.
+	t.Setenv("MCP_SHELL_TEST_SECRET", "leaked-secret-value")
+
+	config := SecurityConfig{MaxExecutionTime: 5 * time.Second}
+	executor := newCommandExecutor(config, logger)
+
+	result, err := executor.executeSecureCommand(ctx, "env", false)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.NotContains(t, result.Stdout, "leaked-secret-value")
+	assert.NotContains(t, result.Stdout, "MCP_SHELL_TEST_SECRET")
+}
+
+func TestCommandExecutor_gitRepoConfigIsNeutralised(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+	ctx := context.Background()
+
+	repo := t.TempDir()
+	sentinel := filepath.Join(t.TempDir(), "git-pwned")
+	hook := filepath.Join(repo, "evil.sh")
+	require.NoError(t, os.WriteFile(hook, []byte("#!/bin/sh\ntouch "+sentinel+"\n"), 0o755))
+
+	runGit := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git %v: %s", args, out)
+	}
+	runGit("init")
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "a.txt"), []byte("one\n"), 0o644))
+	runGit("add", "a.txt")
+	runGit("commit", "-m", "init")
+	// Every repo-local vector git reads from the filesystem instead of argv:
+	// fsmonitor (status), diff.external and per-path textconv (diff/show/log -p).
+	runGit("config", "core.fsmonitor", hook)
+	runGit("config", "diff.external", hook)
+	require.NoError(t, os.WriteFile(filepath.Join(repo, ".gitattributes"), []byte("a.txt diff=evil\n"), 0o644))
+	runGit("config", "diff.evil.textconv", hook)
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "a.txt"), []byte("two\n"), 0o644))
+	runGit("add", "a.txt", ".gitattributes")
+	runGit("commit", "-m", "second")
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "a.txt"), []byte("three\n"), 0o644))
+
+	config := SecurityConfig{WorkingDirectory: repo, MaxExecutionTime: 5 * time.Second}
+	executor := newCommandExecutor(config, logger)
+
+	// None of these read-only commands may run the repo-configured program.
+	for _, command := range []string{"git status", "git diff", "git show", "git log -p"} {
+		t.Run(command, func(t *testing.T) {
+			require.NoError(t, os.RemoveAll(sentinel))
+			_, err := executor.executeSecureCommand(ctx, command, false)
+			require.NoError(t, err)
+			assert.NoFileExists(t, sentinel, "%q must not run a repo-configured program", command)
+		})
+	}
+
+	// The hardening must not break ordinary read-only output.
+	t.Run("git log --oneline still works", func(t *testing.T) {
+		result, err := executor.executeSecureCommand(ctx, "git log --oneline", false)
+		require.NoError(t, err)
+		assert.Equal(t, "success", result.Status)
+		assert.Contains(t, result.Stdout, "second")
+	})
+}
+
+func TestCommandExecutor_outputCapStopsRunawayOutput(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+	ctx := context.Background()
+
+	config := SecurityConfig{MaxOutputSize: 1024, MaxExecutionTime: 30 * time.Second}
+	executor := newCommandExecutor(config, logger)
+
+	start := time.Now()
+	_, err := executor.executeSecureCommand(ctx, "cat /dev/zero", false)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum size limit")
+	// The overflow must stop the child promptly, not run out MaxExecutionTime
+	// while /dev/zero fills memory.
+	assert.Less(t, elapsed, 10*time.Second)
 }
 
 func TestCommandExecutor_failsClosedOnSetupErrors(t *testing.T) {

--- a/security.go
+++ b/security.go
@@ -24,36 +24,45 @@ func newSecurityValidator(cfg SecurityConfig, logger zerolog.Logger) *SecurityVa
 		unfurler: newCommandUnfurler(),
 		policies: newDefaultPolicySet(),
 	}
-	v.warnOnInterpreters()
+	v.warnOnUnclassified()
 	return v
 }
 
-// warnOnInterpreters flags allowlisted executables that can execute arbitrary
-// commands regardless of metacharacter checks (shell/language interpreters, and
-// git via `-c alias.x=!cmd`). Allowing one defeats secure mode; the warning
-// surfaces the misconfiguration at startup instead of silently trusting it.
-func (v *SecurityValidator) warnOnInterpreters() {
+// warnOnUnclassified flags allowlisted executables that secure mode will
+// reject anyway because they are neither data-only nor governed by an argument
+// policy (GHSA-gg85-6grh-63fp: enumerating dangerous binaries is inherently
+// incomplete, so unclassified means denied). The warning surfaces the dead
+// allowlist entry at startup instead of failing every call silently.
+func (v *SecurityValidator) warnOnUnclassified() {
 	if !v.config.Enabled || v.config.UseShellExecution {
 		return
 	}
 	for _, exe := range v.config.AllowedExecutables {
-		if isInterpreterExecutable(filepath.Base(exe)) {
+		if !v.isClassifiedExecutable(exe) {
 			v.logger.Warn().
 				Str("executable", exe).
-				Msg("allowed executable can run arbitrary commands (interpreter or alias-capable) - this defeats secure mode regardless of metacharacter filtering")
+				Msg("allowed executable is not classified as safe (no argument policy, not data-only) - secure mode will reject it")
 		}
 	}
 }
 
-// isInterpreterExecutable reports whether base names an executable that can
-// itself run arbitrary commands, making executable-allowlisting ineffective.
-func isInterpreterExecutable(base string) bool {
-	switch base {
-	case "bash", "sh", "zsh", "fish", "dash", "ksh", "csh", "tcsh",
-		"python", "python2", "python3", "perl", "ruby", "node", "php", "git":
-		return true
-	}
-	return false
+// dataOnlyExecutables names utilities that transform or report data and
+// nothing else: they cannot execute other programs and cannot write to a
+// caller-chosen path. Executables outside this set need an argPolicy to run in
+// secure mode; interpreters and command wrappers (env, timeout, nice, xargs,
+// busybox, ...) are excluded by construction rather than enumerated.
+var dataOnlyExecutables = newStringSet(
+	"ls", "pwd", "whoami", "date", "echo", "printf",
+	"cat", "grep", "wc", "head", "tail", "tr", "cut",
+	"basename", "dirname", "realpath", "readlink", "stat", "du", "df",
+	"uname", "id",
+	"md5sum", "sha1sum", "sha256sum", "sha512sum", "base64",
+)
+
+// isClassifiedExecutable reports whether secure mode knows the executable to
+// be safe: either data-only, or restricted by a per-tool argument policy.
+func (v *SecurityValidator) isClassifiedExecutable(executable string) bool {
+	return v.policies.governs(executable) || dataOnlyExecutables.has(filepath.Base(executable))
 }
 
 func (v *SecurityValidator) validateCommand(command string) error {
@@ -100,19 +109,35 @@ func (v *SecurityValidator) validateExecutableCommand(command string) error {
 
 	executable := res.Argv[0]
 
+	// A relative argv[0] with a path separator ("./ls", "sub/ls") is
+	// existence-checked against the server CWD but executed relative to the
+	// configured WorkingDirectory, so validation and execution can resolve
+	// different files. Only a bare name (PATH lookup) or an absolute path is
+	// unambiguous; reject anything in between.
+	if !filepath.IsAbs(executable) && strings.ContainsRune(executable, filepath.Separator) {
+		return fmt.Errorf("relative executable paths are not allowed in secure mode: %q", executable)
+	}
+
 	for _, allowed := range v.config.AllowedExecutables {
 		if v.matchesExecutable(executable, allowed) {
-			// An interpreter defeats the allowlist by executing whatever it is
-			// handed. Hard-deny it unless a per-tool policy governs its arguments.
-			if isInterpreterExecutable(filepath.Base(executable)) && !v.policies.governs(executable) {
-				return fmt.Errorf("executable '%s' is an interpreter and cannot be allowed in secure mode", executable)
+			// Deny-by-default classification: enumerating binaries that can run
+			// arbitrary commands (interpreters, wrappers like env/timeout/nice)
+			// is inherently incomplete, so anything not affirmatively known safe
+			// is rejected even when allowlisted (GHSA-gg85-6grh-63fp).
+			if !v.isClassifiedExecutable(executable) {
+				return fmt.Errorf(
+					"executable '%s' is not classified as safe in secure mode: it is not a data-only utility and has no argument policy",
+					executable,
+				)
 			}
 			if err := v.policies.check(res.Argv); err != nil {
 				return err
 			}
-			// Apply blocked_patterns and blocked_commands to restrict specific
-			// arguments (e.g. block "git remote -v" while allowing git).
-			if err := v.checkBlockedPatternsAndCommands(command); err != nil {
+			// Apply blocked_patterns and blocked_commands to the resolved argv,
+			// not the raw command: matching the source string lets split quotes
+			// ("cat /etc/pass\"wd\"") produce the target argv while evading the
+			// filter. The normalised argv is what actually runs.
+			if err := v.checkBlockedPatternsAndCommands(strings.Join(res.Argv, " ")); err != nil {
 				return err
 			}
 			v.logger.Debug().

--- a/security_test.go
+++ b/security_test.go
@@ -61,6 +61,20 @@ func TestSecurityValidator_validateCommand(t *testing.T) {
 			errorContains: "no allowed executables configured",
 		},
 		{
+			// blocked_commands is matched against the resolved argv, so a split
+			// quote that rebuilds the same argv cannot evade it.
+			name: "secure mode blocked_commands - split-quote evasion is caught on argv",
+			config: SecurityConfig{
+				Enabled:            true,
+				UseShellExecution:  false,
+				AllowedExecutables: []string{"cat"},
+				BlockedCommands:    []string{"/etc/passwd"},
+			},
+			command:       `cat /etc/pass"wd"`,
+			expectError:   true,
+			errorContains: "blocked keyword",
+		},
+		{
 			name: "legacy mode with allowed commands - allows echo",
 			config: SecurityConfig{
 				Enabled:           true,
@@ -130,16 +144,30 @@ func TestSecurityValidator_validateCommand(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "secure mode with blocked_commands - blocks rm in allowed ls",
+			name: "secure mode with blocked_commands - blocks flagged args of allowed ls",
+			config: SecurityConfig{
+				Enabled:            true,
+				UseShellExecution:  false,
+				AllowedExecutables: []string{"ls"},
+				BlockedCommands:    []string{"-la"},
+			},
+			command:       "ls -la /tmp",
+			expectError:   true,
+			errorContains: "blocked keyword",
+		},
+		// GHSA-gg85-6grh-63fp follow-through: an allowlisted executable that is
+		// neither data-only nor policy-governed (rm) is rejected at
+		// classification, before blocked_commands even applies.
+		{
+			name: "secure mode rejects unclassified rm despite allowlist entry",
 			config: SecurityConfig{
 				Enabled:            true,
 				UseShellExecution:  false,
 				AllowedExecutables: []string{"ls", "rm"},
-				BlockedCommands:    []string{"rm -rf"},
 			},
 			command:       "rm -rf /tmp",
 			expectError:   true,
-			errorContains: "blocked keyword",
+			errorContains: "not classified as safe",
 		},
 		// GHSA-74hp-mggr-hv58: git shell-alias bypass via `-c alias.x=!cmd`.
 		// Now caught by the per-tool git argument policy, not metacharacters.
@@ -229,12 +257,82 @@ func TestSecurityValidator_validateExecutableCommand(t *testing.T) {
 			expectError:        true,
 			errorContains:      "empty command",
 		},
+		// GHSA-gg85-6grh-63fp: command-wrapper utilities (env, timeout, nice, ...)
+		// run an arbitrary command taken from a literal argument. Allowlisting one
+		// must not grant it execution: only executables classified as data-only or
+		// governed by an argument policy are accepted.
+		{
+			name:               "wrapper env is rejected even when allowlisted",
+			allowedExecutables: []string{"env", "cat"},
+			command:            "env touch /tmp/pwned",
+			expectError:        true,
+			errorContains:      "not classified as safe",
+		},
+		{
+			name:               "wrapper timeout is rejected even when allowlisted",
+			allowedExecutables: []string{"timeout"},
+			command:            "timeout 5 touch /tmp/pwned",
+			expectError:        true,
+			errorContains:      "not classified as safe",
+		},
+		{
+			name:               "wrapper nice is rejected even when allowlisted",
+			allowedExecutables: []string{"nice"},
+			command:            "nice touch /tmp/pwned",
+			expectError:        true,
+			errorContains:      "not classified as safe",
+		},
+		{
+			name:               "unclassified allowlisted executable is rejected",
+			allowedExecutables: []string{"rsync"},
+			command:            "rsync a b",
+			expectError:        true,
+			errorContains:      "not classified as safe",
+		},
+		{
+			// tar is no longer classified: -f names an arbitrary write path in any
+			// create/extract mode, so allowlisting it must not grant execution.
+			name:               "tar is rejected as unclassified",
+			allowedExecutables: []string{"tar"},
+			command:            "tar -cf /home/user/.bashrc x",
+			expectError:        true,
+			errorContains:      "not classified as safe",
+		},
+		{
+			name:               "data-only executable in allowlist still passes",
+			allowedExecutables: []string{"cat"},
+			command:            "cat /etc/hostname",
+			expectError:        false,
+		},
+		{
+			name:               "policy-governed executable in allowlist still passes",
+			allowedExecutables: []string{"git"},
+			command:            "git status",
+			expectError:        false,
+		},
 		{
 			name:               "whitespace only command",
 			allowedExecutables: []string{"ls"},
 			command:            "   ",
 			expectError:        true,
 			errorContains:      "empty command",
+		},
+		// A relative argv[0] with a separator is existence-checked against the
+		// server CWD but executed relative to WorkingDirectory, so validation and
+		// execution can resolve different files. Reject it outright.
+		{
+			name:               "relative executable with leading dot is rejected",
+			allowedExecutables: []string{"ls"},
+			command:            "./ls -la",
+			expectError:        true,
+			errorContains:      "relative executable",
+		},
+		{
+			name:               "relative executable in subdir is rejected",
+			allowedExecutables: []string{"ls"},
+			command:            "sub/dir/ls",
+			expectError:        true,
+			errorContains:      "relative executable",
 		},
 	}
 

--- a/unfurl.go
+++ b/unfurl.go
@@ -46,6 +46,12 @@ func (u *commandUnfurler) unfurl(command string) unfurlResult {
 	if strings.TrimSpace(command) == "" {
 		return unfurlResult{Reason: "empty command"}
 	}
+	// The parser silently drops NUL bytes, so a command carrying one would parse
+	// and execute as a different argv than the audited string. Reject it here,
+	// the single source both the validator and the executor share.
+	if strings.ContainsRune(command, 0) {
+		return unfurlResult{Reason: "command contains a NUL byte"}
+	}
 
 	parser := u.parsers.Get().(*syntax.Parser)
 	defer u.parsers.Put(parser)

--- a/unfurl_test.go
+++ b/unfurl_test.go
@@ -146,6 +146,13 @@ func TestCommandUnfurler_unfurl(t *testing.T) {
 			command:     `echo $'\143hmod'`,
 			wantAllowed: false,
 		},
+		{
+			// The parser silently drops NUL, so a smuggled NUL would make the
+			// executed argv differ from the audited string. Reject up front.
+			name:        "nul byte is rejected",
+			command:     "cat /etc/pass\x00wd",
+			wantAllowed: false,
+		},
 	}
 
 	unfurler := newCommandUnfurler()


### PR DESCRIPTION
## What

Harden secure mode. Inverts the executable model to **deny-by-default classification** (closing GHSA-gg85-6grh-63fp) and closes a batch of weaknesses found by auditing that change with three independent security passes.

## Classification (GHSA-gg85-6grh-63fp)

An allowlisted executable now runs only if it is a **data-only utility** or **governed by an argument policy**. Command wrappers (`env`, `timeout`, `nice`, `xargs`, `setsid`, ...) and any unclassified binary are rejected even when allowlisted, so there is no denylist of "dangerous binaries" to keep chasing.

- `uniq` gains a policy that rejects its positional output file (`uniq in out` = arbitrary write).
- `tar` is **dropped** from the governed set: its useful modes all write a caller-chosen path (`tar -cf <path>`), so it is not classifiable as safe. Allowlisting it is now rejected as unclassified.

## Executor

- **Minimal child environment.** The server env and any `.env` are no longer inherited. `cat /proc/self/environ` / `env` can no longer exfiltrate secrets exported by the client or loaded at startup.
- **git repo-local RCE closed.** git reads program-executing instructions from `.git/config` and `.gitattributes`, invisible to any argv check. `core.fsmonitor` is disabled and `diff`/`show`/`blame`/`log` get `--no-ext-diff`/`--no-textconv` injected, so a hostile repository's `diff.external` or `textconv` driver cannot run during a read-only command.
- **`max_output_size` enforced at write time**, cancelling the child on overflow instead of checking after it has already filled memory (`cat /dev/zero` no longer OOMs the server).

## Validator / config

- **Relative `argv[0]` with a separator rejected** (`./ls`): it was existence-checked against one directory and executed relative to another.
- **NUL in the command string rejected** (the parser silently dropped it, so the audit log diverged from what ran).
- **`blocked_patterns`/`blocked_commands` matched against the resolved argv**, closing a split-quote evasion (`cat /etc/pass"wd"`).
- **Config loader fails closed**: a file that omits keys keeps the secure defaults, and `enabled: false` requires `MCP_SHELL_ALLOW_UNSAFE`.

## Known, documented gap

`branch`/`tag`/`symbolic-ref`/`reflog` can still mutate refs within the repository git runs in. Bounded to the repo (no arbitrary-path write, no execution), lower severity, noted in `SECURITY.md`.

## Tests

Every fix landed red-first. The security-critical ones (git repo-config neutralisation, output cap, blocked_patterns-on-argv) were mutation-checked: reverting the fix turns the test red. `go test -race ./...` is green.

## Notes

- Behaviour changes (relative-path/NUL rejection, minimal env, git flag injection, config fail-closed, tar dropped) warrant a **minor version bump** (next tag `v0.8.0`).
- The `deploy`/CI check will be red: the account is out of GitHub Actions minutes. That is billing noise, not a regression. Local gate (`go test -race ./...`, `go vet`) is green.
